### PR TITLE
Add log out button & validate token for Users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.pnp
 .pnp.js
 
+
 # testing
 /coverage
 

--- a/cypress/integration/onlySubscribersCanRate.feature.js
+++ b/cypress/integration/onlySubscribersCanRate.feature.js
@@ -20,7 +20,7 @@ describe('Only subscribers can use rating functionality', () => {
 
   describe('Successfully', () => {
     beforeEach(() => {
-      cy.intercept('PUT', 'https://fakest-newzz.herokuapp.com/api/ratings', {
+      cy.intercept('POST', 'https://fakest-newzz.herokuapp.com/api/ratings', {
         statusCode: 201,
       });
     });
@@ -105,7 +105,7 @@ describe('Only subscribers can use rating functionality', () => {
           fixture: 'registration.json',
         }
       );
-      cy.intercept('PUT', 'https://fakest-newzz.herokuapp.com/api/ratings', {
+      cy.intercept('POST', 'https://fakest-newzz.herokuapp.com/api/ratings', {
         statusCode: 500,
       });
     });

--- a/cypress/integration/userCanLogOutAfterSession.feature.js
+++ b/cypress/integration/userCanLogOutAfterSession.feature.js
@@ -12,7 +12,6 @@ describe('User is able to logout after being logged in', () => {
       'https://fakest-newzz.herokuapp.com/api/auth/sign_out',
       {
         statusCode: 200,
-        body: { message: 'See you again soon!' },
       }
     );
     cy.intercept('GET', 'https://fakest-newzz.herokuapp.com/api/articles/', {
@@ -24,7 +23,6 @@ describe('User is able to logout after being logged in', () => {
 
     cy.visit('/');
     cy.get('[data-cy=login-button]').click();
-    cy.url('/login');
     cy.get('[data-cy=login-form]').within(() => {
       cy.get('[data-cy=login-email]').type('user@mail.com');
       cy.get('[data-cy=login-password]').type('password');
@@ -36,9 +34,12 @@ describe('User is able to logout after being logged in', () => {
   it('is expected to log the user out', () => {
     cy.get('[data-cy=logout-button]').click();
     cy.get('[data-cy=logout-message]').should('contain', 'See you again soon!');
+    cy.get('[data-cy=login-button]').should('be.visible')
+    cy.get('[data-cy=logout-button]').should('not.be.visible')
   });
 
   it('is expected that the user can no longer rate articles', () => {
+    cy.get('[data-cy=logout-button]').click();
     cy.get('[data-cy=article-card-1]').click();
     cy.get('[data-cy=article-rating-button]').find('i').eq(4).click();
     cy.get('#rating-message').should(

--- a/cypress/integration/userCanLogOutAfterSession.feature.js
+++ b/cypress/integration/userCanLogOutAfterSession.feature.js
@@ -1,0 +1,49 @@
+describe('User is able to logout after being logged in', () => {
+  beforeEach(() => {
+    cy.intercept(
+      'POST',
+      'https://fakest-newzz.herokuapp.com/api/auth/sign_in',
+      {
+        fixture: 'registration.json',
+      }
+    );
+    cy.intercept(
+      'DELETE',
+      'https://fakest-newzz.herokuapp.com/api/auth/sign_out',
+      {
+        statusCode: 200,
+        body: { message: 'See you again soon!' },
+      }
+    );
+    cy.intercept('GET', 'https://fakest-newzz.herokuapp.com/api/articles/', {
+      fixture: 'articles.json',
+    });
+    cy.intercept('GET', 'https://fakest-newzz.herokuapp.com/api/articles/3', {
+      fixture: 'specificArticle.json',
+    });
+
+    cy.visit('/');
+    cy.get('[data-cy=login-button]').click();
+    cy.url('/login');
+    cy.get('[data-cy=login-form]').within(() => {
+      cy.get('[data-cy=login-email]').type('user@mail.com');
+      cy.get('[data-cy=login-password]').type('password');
+      cy.get('[data-cy=login-submit]').click();
+      cy.wait(3000);
+    });
+  });
+
+  it('is expected to log the user out', () => {
+    cy.get('[data-cy=logout-button]').click();
+    cy.get('[data-cy=logout-message]').should('contain', 'See you again soon!');
+  });
+
+  it('is expected that the user can no longer rate articles', () => {
+    cy.get('[data-cy=article-card-1]').click();
+    cy.get('[data-cy=article-rating-button]').find('i').eq(4).click();
+    cy.get('#rating-message').should(
+      'contain',
+      'You have to subscribe to be able to rate'
+    );
+  });
+});

--- a/cypress/integration/userCanLogOutAfterSession.feature.js
+++ b/cypress/integration/userCanLogOutAfterSession.feature.js
@@ -33,9 +33,9 @@ describe('User is able to logout after being logged in', () => {
 
   it('is expected to log the user out', () => {
     cy.get('[data-cy=logout-button]').click();
-    cy.get('[data-cy=logout-message]').should('contain', 'See you again soon!');
-    cy.get('[data-cy=login-button]').should('be.visible')
-    cy.get('[data-cy=logout-button]').should('not.be.visible')
+    cy.get('[data-cy=popup-message]').should('contain', 'See you again soon!');
+    cy.get('[data-cy=login-button]').should('be.visible');
+    cy.get('[data-cy=logout-button]').should('not.exist');
   });
 
   it('is expected that the user can no longer rate articles', () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { useSelector } from 'react-redux'
+import React, { useEffect } from 'react';
 import Navbar from './components/layout/Navbar';
 import MainPage from './components/MainPage';
 import Footer from './components/layout/Footer';
@@ -11,13 +10,15 @@ import Registration from './components/Register';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import Popup from './components/Popup';
+import Authentication from './modules/Authentication';
 
-const stripePromise = loadStripe(
-  'pk_test_51IovvJL7WvJmM60Hf2OVas98LZcERwohgrfHfsqEpnjGYIenQB6aNPFBPFmxIYf2enlQYKtWdLae7Jgjv1FwLwsE00r9IeAFuD'
-);
+const stripePromise = loadStripe(process.env.REACT_APP_STRIPE_API_KEY);
 
 const App = () => {
-  const { error } = useSelector((state) => state);
+  useEffect(() => {
+    Authentication.validateToken();
+  }, []);
+
   return (
     <>
       <Navbar />
@@ -40,7 +41,7 @@ const App = () => {
           </Elements>
         </Route>
       </Switch>
-      {error && <Popup />}
+      <Popup />
       <Footer />
     </>
   );

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { useSelector } from 'react-redux'
+import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Segment, Menu } from 'semantic-ui-react';
 import Authentication from '../../modules/Authentication';
 import store from '../../state/store/configureStore';
 
 const Navbar = () => {
-  const { subscriber } = useSelector(state => state)
-  
+  const { subscriber } = useSelector((state) => state);
+
   return (
     <>
       <Segment data-cy='navbar' id='navbar' inverted size='tiny'>
@@ -47,6 +47,9 @@ const Navbar = () => {
           </Menu.Menu>
         </Menu>
       </Segment>
+      <div>
+
+      </div>
       <Link data-cy='header' to='/'>
         <div id='fakenews'>
           FAKE<span id='question'> ? </span>NEWS

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom';
 import { Segment, Menu } from 'semantic-ui-react';
+import Authentication from '../../modules/Authentication';
 import store from '../../state/store/configureStore';
 
 const Navbar = () => {
+  const { subscriber } = useSelector(state => state)
+  
   return (
     <>
       <Segment data-cy='navbar' id='navbar' inverted size='tiny'>
@@ -22,13 +26,24 @@ const Navbar = () => {
             onClick={() => store.dispatch({ type: 'ERROR_RESET' })}
           />
           <Menu.Menu position='right'>
-            <Menu.Item
-              name='Login'
-              data-cy='login-button'
-              active
-              as={Link}
-              to='/login'
-            />
+            {subscriber ? (
+              <Menu.Item
+                name='Logout'
+                data-cy='logout-button'
+                active
+                as={Link}
+                to='/'
+                onClick={() => Authentication.logout()}
+              />
+            ) : (
+              <Menu.Item
+                name='Login'
+                data-cy='login-button'
+                active
+                as={Link}
+                to='/login'
+              />
+            )}
           </Menu.Menu>
         </Menu>
       </Segment>

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -47,9 +47,6 @@ const Navbar = () => {
           </Menu.Menu>
         </Menu>
       </Segment>
-      <div>
-
-      </div>
       <Link data-cy='header' to='/'>
         <div id='fakenews'>
           FAKE<span id='question'> ? </span>NEWS

--- a/src/modules/Articles.js
+++ b/src/modules/Articles.js
@@ -35,7 +35,7 @@ const Articles = {
       article_id: id,
     };
     try {
-      await axios.put('/ratings', params, { headers: getUserAuthToken() });
+      await axios.post('/ratings', params, { headers: getUserAuthToken() });
       store.dispatch({
         type: 'SUCCESS_MESSAGE',
       });

--- a/src/modules/Authentication.js
+++ b/src/modules/Authentication.js
@@ -34,6 +34,7 @@ const Authentication = {
           type: 'LOG_OUT',
           payload: 'See you again soon!',
         });
+        localStorage.clear();
       })
       .catch((error) => {
         errorHandler(error);

--- a/src/modules/Authentication.js
+++ b/src/modules/Authentication.js
@@ -76,7 +76,6 @@ const Authentication = {
     axios
       .get('/auth/validate_token', { headers: getUserAuthToken() })
       .then((response) => {
-        debugger;
         localStorage.setItem('user_headers', JSON.stringify(response.headers));
         store.dispatch({ type: 'AUTHENTICATE' });
       })

--- a/src/modules/Authentication.js
+++ b/src/modules/Authentication.js
@@ -23,6 +23,18 @@ const Authentication = {
       });
   },
 
+  async logout() {
+    axios.delete('auth/sign_out', { headers: getUserAuthToken() })
+    .then(() => {
+      store.dispatch({
+        type: 'LOG_OUT',
+        payload: 'See you again soon!'
+      })
+    }).catch((error) => {
+      errorHandler(error)
+    })
+  },
+
   async subscribe(event, result, setLoading) {
     if (result.token) {
       axios
@@ -66,4 +78,7 @@ const createParams = (event) => {
     password: event.target.password.value,
     password_confirmation: event.target.passwordConfirmation.value,
   };
+};
+const getUserAuthToken = () => {
+  return JSON.parse(localStorage.getItem('user_data'));
 };

--- a/src/modules/Authentication.js
+++ b/src/modules/Authentication.js
@@ -8,13 +8,16 @@ const Authentication = {
       email: event.target.email.value,
       password: event.target.password.value,
     };
-
     axios
       .post('auth/sign_in', params)
       .then((createResponse) => {
         let name = createResponse.data.data.first_name;
+        localStorage.setItem(
+          'user_headers',
+          JSON.stringify(createResponse.headers)
+        );
         store.dispatch({
-          type: 'SET_SUBSCRIBE',
+          type: 'AUTHENTICATE',
           payload: `Welcome back, ${name}!`,
         });
       })
@@ -24,15 +27,17 @@ const Authentication = {
   },
 
   async logout() {
-    axios.delete('auth/sign_out', { headers: getUserAuthToken() })
-    .then(() => {
-      store.dispatch({
-        type: 'LOG_OUT',
-        payload: 'See you again soon!'
+    axios
+      .delete('auth/sign_out', { headers: getUserAuthToken() })
+      .then(() => {
+        store.dispatch({
+          type: 'LOG_OUT',
+          payload: 'See you again soon!',
+        });
       })
-    }).catch((error) => {
-      errorHandler(error)
-    })
+      .catch((error) => {
+        errorHandler(error);
+      });
   },
 
   async subscribe(event, result, setLoading) {
@@ -51,7 +56,7 @@ const Authentication = {
             .then((subscriptionResponse) => {
               localStorage.setItem('user_headers', JSON.stringify(headers));
               store.dispatch({
-                type: 'SET_SUBSCRIBE',
+                type: 'AUTHENTICATE',
                 payload: `${subscriptionResponse.data.message}, ${name}!`,
               });
             })
@@ -64,6 +69,17 @@ const Authentication = {
         });
     }
     setLoading(false);
+  },
+
+  async validateToken() {
+    axios
+      .get('/auth/validate_token', { headers: getUserAuthToken() })
+      .then((response) => {
+        debugger;
+        localStorage.setItem('user_headers', JSON.stringify(response.headers));
+        store.dispatch({ type: 'AUTHENTICATE' });
+      })
+      .catch(() => {});
   },
 };
 

--- a/src/modules/ErrorHandler.js
+++ b/src/modules/ErrorHandler.js
@@ -19,8 +19,7 @@ const errorHandler = (error) => {
       case 401:
         store.dispatch({
           type: 'ERROR_MESSAGE',
-          payload:
-            'Please register an account to do this.',
+          payload: 'Please register an account to do this.',
         });
         break;
       case 422:

--- a/src/state/reducers/rootReducers.js
+++ b/src/state/reducers/rootReducers.js
@@ -20,6 +20,14 @@ const rootReducer = (state, action) => {
         message: action.payload,
         subscriber: true,
       };
+
+    case 'LOG_OUT':
+      return {
+        ...state,
+        message: action.payload,
+        subscriber: false,
+      };
+      
     case 'SET_ARTICLES':
       return {
         ...state,

--- a/src/state/reducers/rootReducers.js
+++ b/src/state/reducers/rootReducers.js
@@ -14,7 +14,7 @@ const rootReducer = (state, action) => {
         open: false,
       };
 
-    case 'SET_SUBSCRIBE':
+    case 'AUTHENTICATE':
       return {
         ...state,
         message: action.payload,
@@ -25,9 +25,10 @@ const rootReducer = (state, action) => {
       return {
         ...state,
         message: action.payload,
+        open: true,
         subscriber: false,
       };
-      
+
     case 'SET_ARTICLES':
       return {
         ...state,

--- a/src/state/store/initialState.js
+++ b/src/state/store/initialState.js
@@ -2,7 +2,8 @@ const initialState = {
   error: false,
   articles: [],
   article: {},
-  subscriber: false
+  subscriber: false,
+  open: false,
 };
 
 export default initialState;


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/178214061)
### User Story 
``` 
As a logged in user
In order to have a more seamless authentication
I want the site to remember be, but also be in control of if I want to be remembered 
``` 
## Changes proposed in this pull request: 
* Adds logout button that 1) clears localStorage, 2) sets application state, 3) destroys the session
* Adds continuous token validation

## What I have learned working on this feature: 
* Logging out 